### PR TITLE
doc: fix generation of pdf documentation

### DIFF
--- a/interfaces/Makefile.am
+++ b/interfaces/Makefile.am
@@ -115,7 +115,7 @@ doc_DATA = 			\
 	Types.pdf
 
 Types.pdf: Types.texi
-	$(TEXI2PDF) Types.texi; rm Types.aux Types.log Types.toc
+	$(TEXI2PDF) Types.texi; rm -f Types.aux Types.log Types.toc
 endif
 
 libsaftlib_la_LIBADD = $(SIGCPP_LIBS)
@@ -181,7 +181,12 @@ $(doc_DATA:.pdf=.doc-xml) $(nodist_libsaftlib_la_SOURCES) $(nodist_saftlib_HEADE
 	$(GDBUS_CODEGEN) --generate-docbook=docfoo --interface-prefix=de.gsi.saftlib $<
 	$(XSLTPROC) --path $(srcdir) fix-docbook.xsl docfoo-de.gsi.saftlib.$*.xml > docfoo-fix.$*.xml
 	$(DOCBOOK2TEXI) --string-param output-file=docfoo-fix.$* docfoo-fix.$*.xml
-	$(TEXI2PDF) docfoo-fix.$*.texi
-	mv docfoo-*.$*.pdf $@
+	grep -v '@node Top' docfoo-fix.$*.texi > docfoo-fix.$*.2.texi
+	$(TEXI2PDF) docfoo-fix.$*.2.texi
+	mv docfoo-*.$*.2.pdf $@
 	rm -f docfoo-de.gsi.saftlib.$*.xml docfoo-fix.$*.*
+
+saftlib-interfaces.pdf: 
+	ls *.pdf | grep -v $@ | grep -v Types.pdf > allpdf.txt
+	pdfunite Types.pdf `cat allpdf.txt` $@
 

--- a/interfaces/Types.texi
+++ b/interfaces/Types.texi
@@ -6,7 +6,6 @@
 * Saftlib: (Types).   Types used in Saftlib interfaces.
 @end direntry
 
-@node Top
 @top Saftlib
 @chapheading Types
 
@@ -27,4 +26,6 @@ s        std::string
 aX       std::vector<X> where X is can be any type
 a@{KV@}    std::map<K,V> K and V are are key and value types
 
+@end example
 @bye
+


### PR DESCRIPTION
fix generation of pdf documentation from xml files. Works on a recent Arch Linux but not on asl-cluster