### PR TITLE
Drop pure declaration from Proxy::signal_dispatch method

### DIFF
--- a/saftbus/client.hpp
+++ b/saftbus/client.hpp
@@ -146,7 +146,7 @@ namespace saftbus {
 		/// 
 		/// @param interface_no refers to the interface (the mapping can be obtained by interface_no_from_name).
 		/// @param signal_no    refers to the signal of a given interface. Signals are numbered by their appearance in the source code.
-		virtual bool signal_dispatch(int interface_no, int signal_no, Deserializer &signal_content) = 0;
+		virtual bool signal_dispatch(int interface_no, int signal_no, Deserializer &signal_content);
 
 		/// @brief The signal group to which this proxy belongs.
 		/// 


### PR DESCRIPTION
This occasionally, but reproducibly, leads to SIGABRT with message

> pure virtual method called
> terminate called without an active exception
> Aborted (core dumped)

 Stack trace of thread 3330:
 #0  0x00007f0edf9e754c __pthread_kill_implementation (libc.so.6 + 0xa154c)
 #1  0x00007f0edf99ad06 raise (libc.so.6 + 0x54d06)
 #2  0x00007f0edf96e885 abort (libc.so.6 + 0x28885)
 #3  0x00007f0edfce6a01 _ZN9__gnu_cxx27__verbose_terminate_handlerEv.cold (libstdc++.so.6 + 0xa1a01)
 #4  0x00007f0edfcf237c _ZN10__cxxabiv111__terminateEPFvvE (libstdc++.so.6 + 0xad37c)
 #5  0x00007f0edfcf23e7 _ZSt9terminatev (libstdc++.so.6 + 0xad3e7)
 #6  0x00007f0edfcf3115 __cxa_pure_virtual (libstdc++.so.6 + 0xae115)
 #7  0x00007f0edff1b250 _ZN7saftbus11SignalGroup19wait_for_one_signalEi (libsaftbus.so.10 + 0x14250)
 #8  0x00007f0edff1b2cf _ZN7saftbus11SignalGroup15wait_for_signalEi (libsaftbus.so.10 + 0x142cf)
 #9  0x00000000004f063a operator() (Genesys_DU + 0xf063a)
 #10 0x00007f0edfd20924 execute_native_thread_routine (libstdc++.so.6 + 0xdb924)
 #11 0x00007f0edf9e5802 start_thread (libc.so.6 + 0x9f802)
 #12 0x00007f0edf985450 __clone3 (libc.so.6 + 0x3f450)

Presumably, a derived Proxy object receives a signal during destruction, just when the object's vtable switched to the base class right before lifetime ends.

While this issue surely is a corner case only likely to happen for applications that heavily create and destroy conditions, I can trigger that quickly with Genesys during typical operation.

After removing the pure declaration I wasn't able to crash the DU.

N.B. C++ pure virtual methods are allowed to have methods defined. Such a definition is present in saftbus/client.cpp. Removing said definition had no influence on the matter.